### PR TITLE
Update dependency to Sidekiq >= 3.2.4 to support Sidekiq 4

### DIFF
--- a/lib/sidekiq/retries/server/middleware.rb
+++ b/lib/sidekiq/retries/server/middleware.rb
@@ -1,4 +1,9 @@
-require 'celluloid'
+begin
+  require 'celluloid'
+rescue LoadError
+  # ignore, seems we're in Sidekiq 4
+end
+
 require 'sidekiq/middleware/server/retry_jobs'
 
 module Sidekiq

--- a/sidekiq-retries.gemspec
+++ b/sidekiq-retries.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'sidekiq', '>= 3.2.4', '~>3.2'
+  spec.add_dependency 'sidekiq', '>= 3.2.4'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,11 @@ end
 require 'rspec/autorun'
 require 'rspec'
 
-require 'celluloid/test'
+begin
+  require 'celluloid/test'
+rescue LoadError
+  # ignore, seems we're in Sidekiq 4
+end
 require 'sidekiq'
 require 'sidekiq/retries'
 require 'sidekiq/cli'


### PR DESCRIPTION
Hello,

Sidekiq 4 [came out yesterday](http://www.mikeperham.com/2015/11/16/sidekiq-4.0/), so I've tried to update my Gemfile. The only library which depends on Sidekiq 3.x was sidekiq-retries. I guess it doesn't make sense now to stick to sidekiq 3.x.